### PR TITLE
T2 Rift moved in Bava Nisos

### DIFF
--- a/Rift Hunting.xml
+++ b/Rift Hunting.xml
@@ -577,7 +577,7 @@
         <!-- BAVA NISOS -->
         <POI MapID="1574" xpos="442.406" ypos="239.833" zpos="474.859"      type="legs.rifts.bn.t1" GUID="OmCpW3cyY0m7xpRwLLSqlg=="/>
         <POI MapID="1574" xpos="-165.959" ypos="124.872" zpos="377.675"     type="legs.rifts.bn.t1" GUID="Z1GSN/J4C0K0cf8asHKe4w=="/>
-        <POI MapID="1574" xpos="-50.1471" ypos="238.747" zpos="-184.872"    type="legs.rifts.bn.t2" GUID="g3RE6ymmfkW+9aW9TnALmg=="/>
+        <POI MapID="1574" xpos="404.583" ypos="151.442" zpos="305.391"      type="legs.rifts.bn.t2" GUID="g3RE6ymmfkW+9aW9TnALmg=="/>
         <POI MapID="1574" xpos="66.4752" ypos="238.904" zpos="-70.9967"     type="legs.rifts.bn.t2" GUID="aZqkfyK0pUOslFtoETao4Q=="/>
         <POI MapID="1574" xpos="-134.587" ypos="8.74973" zpos="-494.988"    type="legs.rifts.bn.t3" GUID="PC9z6sTeDU++nMKpZgHk8g=="/>
         <POI MapID="1574" xpos="53.7412" ypos="13.014" zpos="-607.223"      type="legs.rifts.bn.t3" GUID="IceF4ba+t0WSuKDOI4MetQ=="/>


### PR DESCRIPTION
Seems like they changed one of the T2 rift positions in Bava Nisos to make them a bit further apart.